### PR TITLE
Add recently played games and multilined options

### DIFF
--- a/cmd/box/main.go
+++ b/cmd/box/main.go
@@ -37,13 +37,13 @@ func main() {
 	}
 
 	multiLined := false // boolean for whether hours should have their own line
-	if os.Getenv("MULTILINE") != "" {
-		multiLined, err = strconv.ParseBool(os.Getenv("MULTILINE"))
-		if err != nil {
-			panic("multiLined option error: "+ err.Error())
+	if os.Getenv("LINE_OPTION") != "" {
+		lineOption := os.Getenv("LINE_OPTION")
+		if lineOption == "MULTI" {
+			multiLined = true
 		}
 	}
-	
+
 	updateOption := os.Getenv("UPDATE_OPTION") // options for update: GIST (Gist only), MARKDOWN (README only), GIST_AND_MARKDOWN (Gist and README)
 	markdownFile := os.Getenv("MARKDOWN_FILE") // the markdown filename (e.g. MYFILE.md)
 

--- a/cmd/box/main.go
+++ b/cmd/box/main.go
@@ -30,8 +30,9 @@ func main() {
 	ghUsername := os.Getenv("GH_USER")
 	gistID := os.Getenv("GIST_ID")
 
-	updateOption := os.Getenv("UPDATE_OPTION") // options for update: GIST,MARKDOWN,GIST_AND_MARKDOWN
-	markdownFile := os.Getenv("MARKDOWN_FILE") // the markdown filename
+	steamOption := os.Getenv("STEAM_OPTION") // options for types of games to list: RECENT (recently played games), ALLTIME (playtime of games in descending order)
+	updateOption := os.Getenv("UPDATE_OPTION") // options for update: GIST (Gist only), MARKDOWN (README only), GIST_AND_MARKDOWN (Gist and README)
+	markdownFile := os.Getenv("MARKDOWN_FILE") // the markdown filename (e.g. MYFILE.md)
 
 	var updateGist, updateMarkdown bool
 	if updateOption == "MARKDOWN" {
@@ -47,12 +48,25 @@ func main() {
 
 	ctx := context.Background()
 
-	lines, err := box.GetPlayTime(ctx, steamID, appIDList...)
-	if err != nil {
-		panic("GetPlayTime err:" + err.Error())
-	}
+	var (
+		filename string
+		lines []string
+		err error
+	)
 
-	filename := "🎮 Steam playtime leaderboard"
+	if steamOption == "ALLTIME" {
+		filename = "🎮 Steam playtime leaderboard"
+		lines, err = box.GetPlayTime(ctx, steamID, appIDList...)
+		if err != nil {
+			panic("GetPlayTime err:" + err.Error())
+		}
+	} else if steamOption == "RECENT" {
+		filename = "🎮 Recently played Steam games"
+		lines, err = box.GetRecentGames(ctx, steamID)
+		if err != nil {
+			panic("GetRecentGames err:" + err.Error())
+		}
+	}
 
 	if updateGist {
 		gist, err := box.GetGist(ctx, gistID)
@@ -84,6 +98,6 @@ func main() {
 		if err != nil {
 			fmt.Println(err)
 		}
-		fmt.Println("updating markdown successfully on", markdownFile)
+		fmt.Println("updating markdown successfully on ", markdownFile)
 	}
 }

--- a/cmd/box/main.go
+++ b/cmd/box/main.go
@@ -36,14 +36,14 @@ func main() {
 		steamOption = os.Getenv("STEAM_OPTION")
 	}
 
-	multiLined := false // boolean for whether hours should have their own line
-	if os.Getenv("LINE_OPTION") != "" {
-		lineOption := os.Getenv("LINE_OPTION")
-		if lineOption == "MULTI" {
+	multiLined := false // boolean for whether hours should have their own line - YES = true, NO = false
+	if os.Getenv("MULTILINE") != "" {
+		lineOption := os.Getenv("MULTILINE")
+		if lineOption == "YES" {
 			multiLined = true
 		}
 	}
-
+	
 	updateOption := os.Getenv("UPDATE_OPTION") // options for update: GIST (Gist only), MARKDOWN (README only), GIST_AND_MARKDOWN (Gist and README)
 	markdownFile := os.Getenv("MARKDOWN_FILE") // the markdown filename (e.g. MYFILE.md)
 

--- a/cmd/box/main.go
+++ b/cmd/box/main.go
@@ -13,6 +13,7 @@ import (
 )
 
 func main() {
+	var err error
 	steamAPIKey := os.Getenv("STEAM_API_KEY")
 	steamID, _ := strconv.ParseUint(os.Getenv("STEAM_ID"), 10, 64)
 	appIDs := os.Getenv("APP_ID")
@@ -30,7 +31,19 @@ func main() {
 	ghUsername := os.Getenv("GH_USER")
 	gistID := os.Getenv("GIST_ID")
 
-	steamOption := os.Getenv("STEAM_OPTION") // options for types of games to list: RECENT (recently played games), ALLTIME (playtime of games in descending order)
+	steamOption := "ALLTIME" // options for types of games to list: RECENT (recently played games), ALLTIME <default> (playtime of games in descending order)
+	if os.Getenv("STEAM_OPTION") != "" {
+		steamOption = os.Getenv("STEAM_OPTION")
+	}
+
+	multiLined := false // boolean for whether hours should have their own line
+	if os.Getenv("MULTILINE") != "" {
+		multiLined, err = strconv.ParseBool(os.Getenv("MULTILINE"))
+		if err != nil {
+			panic("multiLined option error: "+ err.Error())
+		}
+	}
+	
 	updateOption := os.Getenv("UPDATE_OPTION") // options for update: GIST (Gist only), MARKDOWN (README only), GIST_AND_MARKDOWN (Gist and README)
 	markdownFile := os.Getenv("MARKDOWN_FILE") // the markdown filename (e.g. MYFILE.md)
 
@@ -51,18 +64,17 @@ func main() {
 	var (
 		filename string
 		lines []string
-		err error
 	)
 
 	if steamOption == "ALLTIME" {
 		filename = "🎮 Steam playtime leaderboard"
-		lines, err = box.GetPlayTime(ctx, steamID, appIDList...)
+		lines, err = box.GetPlayTime(ctx, steamID, multiLined, appIDList...)
 		if err != nil {
 			panic("GetPlayTime err:" + err.Error())
 		}
 	} else if steamOption == "RECENT" {
 		filename = "🎮 Recently played Steam games"
-		lines, err = box.GetRecentGames(ctx, steamID)
+		lines, err = box.GetRecentGames(ctx, steamID, multiLined)
 		if err != nil {
 			panic("GetRecentGames err:" + err.Error())
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/YouEclipse/steam-box
 go 1.14
 
 require (
-	github.com/YouEclipse/steam-go v0.0.0-20200607095305-d18221313a45
+	github.com/YouEclipse/steam-go v0.0.0-20200711125252-eccd89412923
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/mattn/go-runewidth v0.0.9

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/YouEclipse/steam-go v0.0.0-20200607095305-d18221313a45 h1:kUsRRKxquRByz4Jd2e0eF8SYFCnvlipmXbuWSBpWzCI=
 github.com/YouEclipse/steam-go v0.0.0-20200607095305-d18221313a45/go.mod h1:jlP5azGfKH8ZkFb2h1pK2n2JIZlbHbStD841RkwcH7I=
+github.com/YouEclipse/steam-go v0.0.0-20200711125252-eccd89412923 h1:4maE6WS9ueQD1TzZ1pdHgW0Jm4Sb/UOJL1n8eZoGVmY=
+github.com/YouEclipse/steam-go v0.0.0-20200711125252-eccd89412923/go.mod h1:jlP5azGfKH8ZkFb2h1pK2n2JIZlbHbStD841RkwcH7I=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=

--- a/pkg/steambox/box.go
+++ b/pkg/steambox/box.go
@@ -185,5 +185,9 @@ func getNameEmoji(id int, name string) string {
 		return emoji + name
 	}
 
+	if name == "Unknown Game" {
+		return "❓ " + name
+	}
+
 	return "🎮 " + name
 }

--- a/pkg/steambox/box.go
+++ b/pkg/steambox/box.go
@@ -84,7 +84,7 @@ func (b *Box) GetPlayTime(ctx context.Context, steamID uint64, multiLined bool, 
 		if multiLined {
 			gameLine := getNameEmoji(game.Appid, game.Name)
 			lines = append(lines, gameLine)
-			hoursLine := fmt.Sprintf("							🕘 %d hrs %d mins", hours, mins)
+			hoursLine := fmt.Sprintf("						    🕘 %d hrs %d mins", hours, mins)
 			lines = append(lines, hoursLine)
 		} else {
 			line := pad(getNameEmoji(game.Appid, game.Name), " ", 35) + " " +
@@ -125,7 +125,7 @@ func (b *Box) GetRecentGames (ctx context.Context, steamID uint64, multiLined bo
 		if multiLined {
 			gameLine := getNameEmoji(game.Appid, game.Name)
 			lines = append(lines, gameLine)
-			hoursLine := fmt.Sprintf("							🕘 %d hrs %d mins", hours, mins)
+			hoursLine := fmt.Sprintf("						    🕘 %d hrs %d mins", hours, mins)
 			lines = append(lines, hoursLine)
 		} else {
 			line := pad(getNameEmoji(game.Appid, game.Name), " ", 35) + " " +

--- a/pkg/steambox/box.go
+++ b/pkg/steambox/box.go
@@ -52,7 +52,7 @@ func (b *Box) UpdateGist(ctx context.Context, id string, gist *github.Gist) erro
 	return err
 }
 
-// GetPlayTime gets the paytime form steam web API.
+// GetPlayTime gets the top 5 Steam games played in descending order from the Steam API.
 func (b *Box) GetPlayTime(ctx context.Context, steamID uint64, appID ...uint32) ([]string, error) {
 	params := &steam.GetOwnedGamesParams{
 		SteamID:                steamID,
@@ -72,6 +72,36 @@ func (b *Box) GetPlayTime(ctx context.Context, steamID uint64, appID ...uint32) 
 	sort.Slice(gameRet.Games, func(i, j int) bool {
 		return gameRet.Games[i].PlaytimeForever > gameRet.Games[j].PlaytimeForever
 	})
+
+	for _, game := range gameRet.Games {
+		if max >= 5 {
+			break
+		}
+
+		hours := int(math.Floor(float64(game.PlaytimeForever / 60)))
+		mins := int(math.Floor(float64(game.PlaytimeForever % 60)))
+
+		line := pad(getNameEmoji(game.Appid, game.Name), " ", 35) + " " +
+			pad(fmt.Sprintf("🕘 %d hrs %d mins", hours, mins), "", 16)
+		lines = append(lines, line)
+		max++
+	}
+	return lines, nil
+}
+
+// GetRecentGames gets 5 recently played games from the Steam API.
+func (b *Box) GetRecentGames (ctx context.Context, steamID uint64) ([]string, error) {
+	params := &steam.GetRecentlyPlayedGamesParams{
+		SteamID:                steamID,
+		Count:                  5,
+	}
+
+	gameRet, err := b.steam.IPlayerService.GetRecentlyPlayedGames(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	var lines []string
+	var max = 0
 
 	for _, game := range gameRet.Games {
 		if max >= 5 {
@@ -113,7 +143,7 @@ func (b *Box) UpdateMarkdown(ctx context.Context, title, filename string, conten
 
 	err = ioutil.WriteFile(filename, newMd.Bytes(), os.ModeAppend)
 	if err != nil {
-		return fmt.Errorf("steambox.UpdateMarkdown: Error write a file: %w", err)
+		return fmt.Errorf("steambox.UpdateMarkdown: Error writing a file: %w", err)
 	}
 
 	return nil
@@ -132,12 +162,19 @@ func pad(s, pad string, targetLength int) string {
 func getNameEmoji(id int, name string) string {
 	// hard code some game's emoji
 	var nameEmojiMap = map[int]string{
+		70:     "**λ** ", // Half-Life
+		220:    "**λ²** ", // Half-Life 2
+		500:    "🧟 ", // Left 4 Dead
+		550:    "🧟 ", // Left 4 Dead 2
+		570:    "⚔️ ", // Dota 2
 		730:    "🔫 ", // CS:GO
-		271590: "🚓 ", // GTA 5
-		578080: "🍳 ", // PUBG
-		431960: "💻 ", // Wallpaper Engine
 		8930:   "🌏 ", // Sid Meier's Civilization V
+		252950: "🚀 ", // Rocket League
+		271590: "🚓 ", // GTA 5
 		359550: "🔫 ", // Tom Clancy's Rainbow Six Siege
+		431960: "💻 ", // Wallpaper Engine
+		578080: "🍳 ", // PUBG
+		945360: "🕵️‍♂️ ", // Among Us
 	}
 
 	if emoji, ok := nameEmojiMap[id]; ok {

--- a/pkg/steambox/box.go
+++ b/pkg/steambox/box.go
@@ -108,10 +108,14 @@ func (b *Box) GetRecentGames (ctx context.Context, steamID uint64) ([]string, er
 			break
 		}
 
+		if game.Name == "" {
+			game.Name = "Unknown Game"
+		}
+
 		hours := int(math.Floor(float64(game.PlaytimeForever / 60)))
 		mins := int(math.Floor(float64(game.PlaytimeForever % 60)))
 
-		line := pad(getNameEmoji(game.Appid, game.Name), " ", 35) + " " +
+		line := pad(getNameEmoji(game.Appid, game.Name), " ", 33) + " " +
 			pad(fmt.Sprintf("🕘 %d hrs %d mins", hours, mins), "", 16)
 		lines = append(lines, line)
 		max++
@@ -162,8 +166,8 @@ func pad(s, pad string, targetLength int) string {
 func getNameEmoji(id int, name string) string {
 	// hard code some game's emoji
 	var nameEmojiMap = map[int]string{
-		70:     "**λ** ", // Half-Life
-		220:    "**λ²** ", // Half-Life 2
+		70:     "λ ", // Half-Life
+		220:    "λ² ", // Half-Life 2
 		500:    "🧟 ", // Left 4 Dead
 		550:    "🧟 ", // Left 4 Dead 2
 		570:    "⚔️ ", // Dota 2

--- a/pkg/steambox/box.go
+++ b/pkg/steambox/box.go
@@ -84,7 +84,7 @@ func (b *Box) GetPlayTime(ctx context.Context, steamID uint64, multiLined bool, 
 		if multiLined {
 			gameLine := getNameEmoji(game.Appid, game.Name)
 			lines = append(lines, gameLine)
-			hoursLine := fmt.Sprintf("	🕘 %d hrs %d mins", hours, mins)
+			hoursLine := fmt.Sprintf("								🕘 %d hrs %d mins", hours, mins)
 			lines = append(lines, hoursLine)
 		} else {
 			line := pad(getNameEmoji(game.Appid, game.Name), " ", 35) + " " +
@@ -125,7 +125,7 @@ func (b *Box) GetRecentGames (ctx context.Context, steamID uint64, multiLined bo
 		if multiLined {
 			gameLine := getNameEmoji(game.Appid, game.Name)
 			lines = append(lines, gameLine)
-			hoursLine := fmt.Sprintf("	🕘 %d hrs %d mins", hours, mins)
+			hoursLine := fmt.Sprintf("								🕘 %d hrs %d mins", hours, mins)
 			lines = append(lines, hoursLine)
 		} else {
 			line := pad(getNameEmoji(game.Appid, game.Name), " ", 35) + " " +

--- a/pkg/steambox/box.go
+++ b/pkg/steambox/box.go
@@ -115,7 +115,7 @@ func (b *Box) GetRecentGames (ctx context.Context, steamID uint64) ([]string, er
 		hours := int(math.Floor(float64(game.PlaytimeForever / 60)))
 		mins := int(math.Floor(float64(game.PlaytimeForever % 60)))
 
-		line := pad(getNameEmoji(game.Appid, game.Name), " ", 33) + " " +
+		line := pad(getNameEmoji(game.Appid, game.Name), " ", 37) + " " +
 			pad(fmt.Sprintf("🕘 %d hrs %d mins", hours, mins), "", 16)
 		lines = append(lines, line)
 		max++

--- a/pkg/steambox/box.go
+++ b/pkg/steambox/box.go
@@ -84,7 +84,7 @@ func (b *Box) GetPlayTime(ctx context.Context, steamID uint64, multiLined bool, 
 		if multiLined {
 			gameLine := getNameEmoji(game.Appid, game.Name)
 			lines = append(lines, gameLine)
-			hoursLine := fmt.Sprintf("								🕘 %d hrs %d mins", hours, mins)
+			hoursLine := fmt.Sprintf("							🕘 %d hrs %d mins", hours, mins)
 			lines = append(lines, hoursLine)
 		} else {
 			line := pad(getNameEmoji(game.Appid, game.Name), " ", 35) + " " +
@@ -125,7 +125,7 @@ func (b *Box) GetRecentGames (ctx context.Context, steamID uint64, multiLined bo
 		if multiLined {
 			gameLine := getNameEmoji(game.Appid, game.Name)
 			lines = append(lines, gameLine)
-			hoursLine := fmt.Sprintf("								🕘 %d hrs %d mins", hours, mins)
+			hoursLine := fmt.Sprintf("							🕘 %d hrs %d mins", hours, mins)
 			lines = append(lines, hoursLine)
 		} else {
 			line := pad(getNameEmoji(game.Appid, game.Name), " ", 35) + " " +

--- a/pkg/steambox/box.go
+++ b/pkg/steambox/box.go
@@ -53,7 +53,7 @@ func (b *Box) UpdateGist(ctx context.Context, id string, gist *github.Gist) erro
 }
 
 // GetPlayTime gets the top 5 Steam games played in descending order from the Steam API.
-func (b *Box) GetPlayTime(ctx context.Context, steamID uint64, appID ...uint32) ([]string, error) {
+func (b *Box) GetPlayTime(ctx context.Context, steamID uint64, multiLined bool, appID ...uint32) ([]string, error) {
 	params := &steam.GetOwnedGamesParams{
 		SteamID:                steamID,
 		IncludeAppInfo:         true,
@@ -81,16 +81,23 @@ func (b *Box) GetPlayTime(ctx context.Context, steamID uint64, appID ...uint32) 
 		hours := int(math.Floor(float64(game.PlaytimeForever / 60)))
 		mins := int(math.Floor(float64(game.PlaytimeForever % 60)))
 
-		line := pad(getNameEmoji(game.Appid, game.Name), " ", 35) + " " +
-			pad(fmt.Sprintf("🕘 %d hrs %d mins", hours, mins), "", 16)
-		lines = append(lines, line)
+		if multiLined {
+			gameLine := getNameEmoji(game.Appid, game.Name)
+			lines = append(lines, gameLine)
+			hoursLine := fmt.Sprintf("	🕘 %d hrs %d mins", hours, mins)
+			lines = append(lines, hoursLine)
+		} else {
+			line := pad(getNameEmoji(game.Appid, game.Name), " ", 35) + " " +
+				pad(fmt.Sprintf("🕘 %d hrs %d mins", hours, mins), "", 16)
+			lines = append(lines, line)
+		} 
 		max++
 	}
 	return lines, nil
 }
 
 // GetRecentGames gets 5 recently played games from the Steam API.
-func (b *Box) GetRecentGames (ctx context.Context, steamID uint64) ([]string, error) {
+func (b *Box) GetRecentGames (ctx context.Context, steamID uint64, multiLined bool) ([]string, error) {
 	params := &steam.GetRecentlyPlayedGamesParams{
 		SteamID:                steamID,
 		Count:                  5,
@@ -115,9 +122,16 @@ func (b *Box) GetRecentGames (ctx context.Context, steamID uint64) ([]string, er
 		hours := int(math.Floor(float64(game.PlaytimeForever / 60)))
 		mins := int(math.Floor(float64(game.PlaytimeForever % 60)))
 
-		line := pad(getNameEmoji(game.Appid, game.Name), " ", 37) + " " +
-			pad(fmt.Sprintf("🕘 %d hrs %d mins", hours, mins), "", 16)
-		lines = append(lines, line)
+		if multiLined {
+			gameLine := getNameEmoji(game.Appid, game.Name)
+			lines = append(lines, gameLine)
+			hoursLine := fmt.Sprintf("	🕘 %d hrs %d mins", hours, mins)
+			lines = append(lines, hoursLine)
+		} else {
+			line := pad(getNameEmoji(game.Appid, game.Name), " ", 35) + " " +
+				pad(fmt.Sprintf("🕘 %d hrs %d mins", hours, mins), "", 16)
+			lines = append(lines, line)
+		} 
 		max++
 	}
 	return lines, nil
@@ -174,11 +188,13 @@ func getNameEmoji(id int, name string) string {
 		730:    "🔫 ", // CS:GO
 		8930:   "🌏 ", // Sid Meier's Civilization V
 		252950: "🚀 ", // Rocket League
+		269950: "✈️ ", // X-Plane 11
 		271590: "🚓 ", // GTA 5
 		359550: "🔫 ", // Tom Clancy's Rainbow Six Siege
 		431960: "💻 ", // Wallpaper Engine
 		578080: "🍳 ", // PUBG
 		945360: "🕵️‍♂️ ", // Among Us
+		1250410: "🛩️ ", // Microsoft Flight Simulator
 	}
 
 	if emoji, ok := nameEmojiMap[id]; ok {

--- a/pkg/steambox/box_test.go
+++ b/pkg/steambox/box_test.go
@@ -32,8 +32,23 @@ func TestBox_GetPlayTime(t *testing.T) {
 		t.Error(err)
 	}
 	t.Log(strings.Join(lines, "\n"))
-
 }
+
+func TestBox_GetRecentGames(t *testing.T) {
+	steamAPIKey := os.Getenv("STEAM_API_KEY")
+	steamID, _ := strconv.ParseUint(os.Getenv("STEAM_ID"), 10, 64)
+
+	ghToken := os.Getenv("GH_TOKEN")
+	ghUsername := os.Getenv("GH_USER")
+
+	box := NewBox(steamAPIKey, ghUsername, ghToken)
+	lines, err := box.GetRecentGames(context.Background(), steamID)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Log(strings.Join(lines, "\n"))
+}
+
 func TestBox_Readme(t *testing.T) {
 
 	ghToken := os.Getenv("GH_TOKEN")

--- a/pkg/steambox/box_test.go
+++ b/pkg/steambox/box_test.go
@@ -52,11 +52,11 @@ func TestBox_GetRecentGames(t *testing.T) {
 	ghToken := os.Getenv("GH_TOKEN")
 	ghUsername := os.Getenv("GH_USER")
 
-	multiLined := false // boolean for whether hours should have their own line
+	multiLined := false // boolean for whether hours should have their own line - YES = true, NO = false
 	if os.Getenv("MULTILINE") != "" {
-		multiLined, err = strconv.ParseBool(os.Getenv("MULTILINE"))
-		if err != nil {
-			panic("multiLined option error: "+ err.Error())
+		lineOption := os.Getenv("MULTILINE")
+		if lineOption == "YES" {
+			multiLined = true
 		}
 	}
 

--- a/pkg/steambox/box_test.go
+++ b/pkg/steambox/box_test.go
@@ -10,8 +10,18 @@ import (
 )
 
 func TestBox_GetPlayTime(t *testing.T) {
+	var err error
 	steamAPIKey := os.Getenv("STEAM_API_KEY")
 	steamID, _ := strconv.ParseUint(os.Getenv("STEAM_ID"), 10, 64)
+
+	multiLined := false // boolean for whether hours should have their own line
+	if os.Getenv("MULTILINE") != "" {
+		multiLined, err = strconv.ParseBool(os.Getenv("MULTILINE"))
+		if err != nil {
+			panic("multiLined option error: "+ err.Error())
+		}
+	}
+
 	appIDs := os.Getenv("APP_ID")
 	appIDList := make([]uint32, 0)
 
@@ -27,7 +37,7 @@ func TestBox_GetPlayTime(t *testing.T) {
 	ghUsername := os.Getenv("GH_USER")
 
 	box := NewBox(steamAPIKey, ghUsername, ghToken)
-	lines, err := box.GetPlayTime(context.Background(), steamID, appIDList...)
+	lines, err := box.GetPlayTime(context.Background(), steamID, multiLined, appIDList...)
 	if err != nil {
 		t.Error(err)
 	}
@@ -35,14 +45,23 @@ func TestBox_GetPlayTime(t *testing.T) {
 }
 
 func TestBox_GetRecentGames(t *testing.T) {
+	var err error
 	steamAPIKey := os.Getenv("STEAM_API_KEY")
 	steamID, _ := strconv.ParseUint(os.Getenv("STEAM_ID"), 10, 64)
 
 	ghToken := os.Getenv("GH_TOKEN")
 	ghUsername := os.Getenv("GH_USER")
 
+	multiLined := false // boolean for whether hours should have their own line
+	if os.Getenv("MULTILINE") != "" {
+		multiLined, err = strconv.ParseBool(os.Getenv("MULTILINE"))
+		if err != nil {
+			panic("multiLined option error: "+ err.Error())
+		}
+	}
+
 	box := NewBox(steamAPIKey, ghUsername, ghToken)
-	lines, err := box.GetRecentGames(context.Background(), steamID)
+	lines, err := box.GetRecentGames(context.Background(), steamID, multiLined)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
So far I've utilised your steam-go library to add the ability to toggle between all time games and recently played games (within last 2 weeks). I wanted to order recently played games by last played but the Steam API unfortunately only sorts them by playtime. Currently I'm working on an option that lets you toggle between single-lined (with word wrapping for the game, hours, etc) and multi-lined (the game name and emoji will be on one line, hours on the next).

I also added some more hardcoded emojis.. 😄 