### PR TITLE
fix: specify steam id type to steamID64

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ English | [简体中文](./README_zh.md)
 1. Create a new public GitHub Gist (https://gist.github.com/)
 1. Create a token with the `gist` scope and copy it. (https://github.com/settings/tokens/new)
 1. Create a Steam  API key. (https://steamcommunity.com/dev/apikey)
-1. Find the steam ID of your account. (https://steamid.io)
+1. Find the steam ID (steamID64) of your account. (https://steamid.io)
 1. For updating a markdown file，add comments to the place where you want to update in the markdown file.
    ```markdown
     <!-- steam-box start -->


### PR DESCRIPTION
I followed README but my action failed at getting play time from API.
Finally I figured out I had to use steamID64. (There is three types of steam id)
Please accept this request and make easier to understand guideline 😄

![스크린샷 2020-12-14 오전 3 38 37](https://user-images.githubusercontent.com/34048253/102020651-db29e000-3dbd-11eb-9148-808fcc6bff35.png)
