### PR TITLE
feat: game emoji

### DIFF
--- a/pkg/steambox/box.go
+++ b/pkg/steambox/box.go
@@ -196,6 +196,10 @@ func getNameEmoji(id int, name string) string {
 		945360:  "🕵️‍♂️ ", // Among Us
 		1250410: "🛩️ ",    // Microsoft Flight Simulator
 		1091500: "🦾 ",     // Cyberpunk 2077
+		594650:  "🎯 ",     // Hunt: Showdown
+		230410:  "🐹 ",     // Warframe
+		397540:  "🤖 ",     // Borderlands 3
+		49520:   "🤖 ",     // Borderlands 2
 	}
 
 	if emoji, ok := nameEmojiMap[id]; ok {


### PR DESCRIPTION
| 游戏名 | Emoji | 含义 |  
| --- | --- | --- |  
| Warframe | 🐹 | 星际仓鼠（至少国内是这种别称） |  
| Hunt: Showdown | 🎯 | 打猎 |  
| Borderlands 2 | 🤖 | 标志角色"小吵闹"（机器人代表，但不太像） |  
| Borderlands 3 | 🤖 | 标志角色"小吵闹"（机器人代表，但不太像） |  